### PR TITLE
build on spark 1.4, fix edge conditions

### DIFF
--- a/bin/build-and-run
+++ b/bin/build-and-run
@@ -17,7 +17,8 @@ import time
 
 # The express-D project directory
 proj_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sbt_cmd = "sbt/sbt"
+#sbt_cmd = "sbt/sbt"
+sbt_cmd = "/usr/bin/sbt"
 
 parser = parser = argparse.ArgumentParser(description='Run Express-D. Before running, '
     'edit the configuration file in express-D/config.')
@@ -137,11 +138,13 @@ else:
     # TODO(andy): Make this check for the jar we will be including on the
     #             classpath (as part of work Patrick is doing), instead of
     #             just looking for spark/target.
-    assert os.path.exists(
-        "%s/target" % config.SPARK_HOME), ("You chose to skip Spark prep, but we can't since " +
-        "%s/target does not exist, so Spark needs to be rebuilt/packaged." % config.SPARK_HOME)
-    print("Skipping preparation tasks for Spark (i.e, git clone or update, checkout, build, " +
-        "copy conf files).")
+
+    print()
+    #assert os.path.exists(
+    #    "%s/target" % config.SPARK_HOME), ("You chose to skip Spark prep, but we can't since " +
+    #    "%s/target does not exist, so Spark needs to be rebuilt/packaged." % config.SPARK_HOME)
+    #print("Skipping preparation tasks for Spark (i.e, git clone or update, checkout, build, " +
+    #    "copy conf files).")
 
 # There is a Spark jar at this point. Build Express-D, if needed.
 spark_work_dir = "%s/spark/work" % proj_dir
@@ -160,6 +163,8 @@ else:
     express_d_jar_path = "%s/target/express-d-assembly.jar" % proj_dir
     assert os.path.exists(express_d_jar_path), ("You tried to skip packaging the Express-D " +
         "source, but %s cannot be found") % express_d_jar_path
+
+assert 0 == 1
 
 # Sync the whole directory to slaves.
 print("Syncing the test directory to the slaves.")

--- a/bin/build-and-run
+++ b/bin/build-and-run
@@ -164,7 +164,7 @@ else:
     assert os.path.exists(express_d_jar_path), ("You tried to skip packaging the Express-D " +
         "source, but %s cannot be found") % express_d_jar_path
 
-assert 0 == 1
+#assert 0 == 1
 
 # Sync the whole directory to slaves.
 print("Syncing the test directory to the slaves.")

--- a/bin/build-and-run
+++ b/bin/build-and-run
@@ -164,8 +164,6 @@ else:
     assert os.path.exists(express_d_jar_path), ("You tried to skip packaging the Express-D " +
         "source, but %s cannot be found") % express_d_jar_path
 
-#assert 0 == 1
-
 # Sync the whole directory to slaves.
 print("Syncing the test directory to the slaves.")
 run_cmds_parallel([(make_rsync_cmd(proj_dir, slave), True) for slave in slaves_list])

--- a/bin/build-and-run
+++ b/bin/build-and-run
@@ -160,7 +160,7 @@ if should_prep_express_d:
     run_cmd("%s clean assembly" % sbt_cmd)
     print("Done assembling Express-D jar.")
 else:
-    express_d_jar_path = "%s/target/express-d-assembly.jar" % proj_dir
+    express_d_jar_path = "%s/target/scala-2.10/express-d-assembly.jar" % proj_dir
     assert os.path.exists(express_d_jar_path), ("You tried to skip packaging the Express-D " +
         "source, but %s cannot be found") % express_d_jar_path
 
@@ -176,7 +176,7 @@ new_env = os.environ.copy()
 new_env["SPARK_HOME"] = config.SPARK_HOME
 new_env["EXPRESS_D_HOME"] = config.EXPRESS_D_HOME
 
-scala_cmd_classpath = "%s/target/express-d-assembly.jar" % proj_dir
+scala_cmd_classpath = "%s/target/scala-2.10/express-d-assembly.jar" % proj_dir
 
 # Run all tests specified in 'tests_to_run', a list of 5-element tuples. See the 'Test Setup'
 # section in config.py.template for more info.

--- a/bin/build-and-run
+++ b/bin/build-and-run
@@ -160,7 +160,7 @@ if should_prep_express_d:
     run_cmd("%s clean assembly" % sbt_cmd)
     print("Done assembling Express-D jar.")
 else:
-    express_d_jar_path = "%s/target/scala-2.10/express-d-assembly.jar" % proj_dir
+    express_d_jar_path = "%s/target/scala-2.10/express-D-assembly.jar" % proj_dir
     assert os.path.exists(express_d_jar_path), ("You tried to skip packaging the Express-D " +
         "source, but %s cannot be found") % express_d_jar_path
 
@@ -176,7 +176,7 @@ new_env = os.environ.copy()
 new_env["SPARK_HOME"] = config.SPARK_HOME
 new_env["EXPRESS_D_HOME"] = config.EXPRESS_D_HOME
 
-scala_cmd_classpath = "%s/target/scala-2.10/express-d-assembly.jar" % proj_dir
+scala_cmd_classpath = "%s/target/scala-2.10/express-D-assembly.jar" % proj_dir
 
 # Run all tests specified in 'tests_to_run', a list of 5-element tuples. See the 'Test Setup'
 # section in config.py.template for more info.

--- a/bin/run
+++ b/bin/run
@@ -21,7 +21,7 @@ import time
 
 # The express-D project directory
 proj_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sbt_cmd = "sbt/sbt"
+sbt_cmd = "/usr/bin/sbt"
 
 parser = parser = argparse.ArgumentParser(description='Run Express-D. Before running, '
     'edit the configuration file in express-D/config.')

--- a/bin/run
+++ b/bin/run
@@ -49,8 +49,8 @@ os.environ["SPARK_HOME"] = config.SPARK_HOME
 os.environ["EXPRESS_D_HOME"] = config.EXPRESS_D_HOME
 
 # Determine what to build based on user-specified variables.
-should_prep_spark = false
-should_prep_express_d = false
+should_prep_spark = False
+should_prep_express_d = False
 
 # Run shell command and ignore output.
 def run_cmd(cmd, exit_on_fail=True):

--- a/bin/run
+++ b/bin/run
@@ -175,7 +175,7 @@ if should_prep_express_d:
     run_cmd("cd %s" % proj_dir)
     run_cmd("%s clean assembly" % sbt_cmd)
 else:
-    express_d_jar_path = "%s/target/scala-2.10/express-d-assembly.jar" % proj_dir
+    express_d_jar_path = "%s/target/scala-2.10/express-D-assembly.jar" % proj_dir
     assert os.path.exists(express_d_jar_path), ("You tried to skip packaging the Express-D " +
         "source, but %s cannot be found") % express_d_jar_path
 
@@ -203,7 +203,7 @@ else:
         "find the following string in spark-env.sh: spark.local.dir=ONE_OR_MORE_DIRNAMES\" so you "
         "will want a line like this: SPARK_JAVA_OPTS+=\" -Dspark.local.dir=/tmp\"")
 
-scala_cmd_classpath = "%s/target/scala-2.10/express-d-assembly.jar" % proj_dir
+scala_cmd_classpath = "%s/target/scala-2.10/express-D-assembly.jar" % proj_dir
 run_express(scala_cmd_classpath)
 
 print("Finished running Express-D")

--- a/bin/run
+++ b/bin/run
@@ -193,7 +193,7 @@ new_env["EXPRESS_D_HOME"] = config.EXPRESS_D_HOME
 path_to_spark_env_file = "%s/spark-env.sh" % config.SPARK_CONF_DIR
 spark_local_directories = ""
 
-env_file_content = open(path_to_env_file, 'r').read()
+env_file_content = open(path_to_spark_env_file, 'r').read()
 re_result = re.search(r'spark.local.dir=([^"]*)"', env_file_content)
 if re_result:
     spark_local_dirs = re_result.group(1).split(",")

--- a/bin/run
+++ b/bin/run
@@ -116,13 +116,13 @@ slaves_file_raw = open("%s/slaves" % config.SPARK_CONF_DIR, 'r').read().split("\
 slaves_list = filter(lambda x: not x.startswith("#") and not x is "", slaves_file_raw)
 
 # If a cluster is already running from the Spark EC2 scripts, try shutting it down.
-if os.path.exists("%s/bin/stop-all.sh" % config.SPARK_HOME_DIR):
-    run_cmd("%s/bin/stop-all.sh" % config.SPARK_HOME_DIR)
+if os.path.exists("%s/sbin/stop-all.sh" % config.SPARK_HOME):
+    run_cmd("%s/sbin/stop-all.sh" % config.SPARK_HOME)
 
 # If a cluster is already running from an earlier test, try shutting it down.
-if os.path.exists("%s/spark/bin/stop-all.sh" % proj_dir):
+if os.path.exists("%s/spark/sbin/stop-all.sh" % proj_dir):
     print("Stopping Spark standalone cluster...")
-    run_cmd("%s/spark/bin/stop-all.sh" % proj_dir)
+    run_cmd("%s/spark/sbin/stop-all.sh" % proj_dir)
 
 # Ensure all shutdowns have completed (no executors are running).
 ensure_spark_stopped_on_slaves(slaves_list)
@@ -154,11 +154,13 @@ else:
     # TODO(andy): Make this check for the jar we will be including on the
     #             classpath (as part of work Patrick is doing), instead of
     #             just looking for spark/target.
-    assert os.path.exists(
-        "%s/spark/target" % proj_dir), ("You chose to skip Spark prep, but we can't since " +
-        "%s/spark/target does not exist, so Spark needs to be rebuilt/packaged." % proj_dir)
-    print("Skipping preparation tasks for Spark (i.e, git clone or update, checkout, build, " +
-        "copy conf files).")
+
+    print()
+    #assert os.path.exists(
+    #    "%s/spark/target" % proj_dir), ("You chose to skip Spark prep, but we can't since " +
+    #    "%s/spark/target does not exist, so Spark needs to be rebuilt/packaged." % proj_dir)
+    #print("Skipping preparation tasks for Spark (i.e, git clone or update, checkout, build, " +
+    #    "copy conf files).")
 
 # There is a Spark jar at this point. Build Express-D, if needed.
 spark_work_dir = "%s/spark/work" % proj_dir
@@ -173,7 +175,7 @@ if should_prep_express_d:
     run_cmd("cd %s" % proj_dir)
     run_cmd("%s clean assembly" % sbt_cmd)
 else:
-    express_d_jar_path = "%s/target/express-d-assembly.jar" % proj_dir
+    express_d_jar_path = "%s/target/scala-2.10/express-d-assembly.jar" % proj_dir
     assert os.path.exists(express_d_jar_path), ("You tried to skip packaging the Express-D " +
         "source, but %s cannot be found") % express_d_jar_path
 
@@ -201,7 +203,7 @@ else:
         "find the following string in spark-env.sh: spark.local.dir=ONE_OR_MORE_DIRNAMES\" so you "
         "will want a line like this: SPARK_JAVA_OPTS+=\" -Dspark.local.dir=/tmp\"")
 
-scala_cmd_classpath = "%s/target/express-d-assembly.jar" % proj_dir
+scala_cmd_classpath = "%s/target/scala-2.10/express-d-assembly.jar" % proj_dir
 run_express(scala_cmd_classpath)
 
 print("Finished running Express-D")

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ libraryDependencies += "org.scalatest" % "scalatest_2.9.2" % "1.8" % "test"
 
 libraryDependencies += "com.google.guava" % "guava" % "14.0.1"
 
+libraryDependencies += "it.unimi.dsi" % "fastutil" % "7.0.8"
+
 unmanagedJars in Compile <++= baseDirectory map { base =>
   val pathToSpark = System.getenv("SPARK_HOME")
   val finder: PathFinder = (file(pathToSpark)) ** "*.jar"

--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,6 @@ unmanagedJars in Compile <++= baseDirectory map { base =>
   finder.get
 }
 
-assemblySettings
-
 test in assembly := {}
 
 jarName in assembly := "express-D-assembly.jar"

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,8 @@
-import AssemblyKeys._
-
 name := "express-D"
 
 version := "0.1"
 
 organization := "math.mcb.berkeley.edu"
-
-scalaVersion := "2.9.3"
 
 libraryDependencies += "org.clapper" % "argot_2.9.2" % "0.4"
 

--- a/config/config.py
+++ b/config/config.py
@@ -64,7 +64,7 @@ SPARK_CLUSTER_URL = "local"
 SPARK_RUNTIME_OPTS = [
     # Fraction of JVM memory used for caching RDDs.
     JavaOptionSet("spark.storage.memoryFraction", [0.66]),
-    JavaOptionSet("spark.serializer", ["spark.JavaSerializer"]),
+    JavaOptionSet("spark.serializer", ["org.apache.spark.serializer.JavaSerializer"]),
     # How much memory to give the Spark process running on each slave.
     JavaOptionSet("spark.executor.memory", ["4g"]),
 ]
@@ -80,8 +80,8 @@ ALL_JAVA_OPTS = SPARK_RUNTIME_OPTS + EXPRESS_RUNTIME_OPTS
 
 # Options local to each Express-D run.
 EXPRESS_RUNTIME_LOCAL_OPTS = [
-    OptionSet("hits-file-path", [""]),
-    OptionSet("targets-file-path", [""]),
+    OptionSet("hits-file-path", ["/mapr/MapR_EMR.amazonaws.com/data/eXpress/x.eXpressD"]),
+    OptionSet("targets-file-path", ["/mapr/MapR_EMR.amazonaws.com/data/eXpress/targets.pb"]),
     OptionSet("should-use-bias", ["true"]),
     OptionSet("num-iterations", ["1000"]),
     OptionSet("should-cache", ["true"]),

--- a/config/config.py
+++ b/config/config.py
@@ -1,0 +1,94 @@
+"""Configuration options for running Express-D"""
+
+import time
+
+from config_utils import FlagSet
+from config_utils import JavaOptionSet
+from config_utils import OptionSet
+
+# Flags that are required to compile eXpress using bin/build-and-run:
+# - SPARK_HOME
+# - SPARK_GIT_REPO
+# - EXPRESS_D_HOME
+#
+# Flags required to run eXpress using bin/build-and-run or bin/run:
+# - SPARK_CLUSER_URL
+# - EXPRESS_RUNTIME_LOCAL_OPTS. The only two absolutely required are below, but the program might
+#   not run as desired unless the other properties are set (e.g., specify 'should-use-bias').
+#   - OptionSet("hits-file-path", [ "/path/to/hits.pb" ])
+#   - OptionSet("targets-file-path", [ "/path/to/targets.pb" ])
+
+# --------------------------------------------------------------------------------------------------
+# Spark + Express-D Build Configuration Options
+# --------------------------------------------------------------------------------------------------
+
+# Required. Location of Spark sources.
+SPARK_HOME = "/opt/mapr/spark/spark-1.4.1"
+SPARK_CONF_DIR = SPARK_HOME + "/conf"
+
+# If true, don't build Spark. This assumes that SPARK_HOME has been assembled using
+# 'sbt/sbt assembly'.
+SPARK_SKIP_PREP = True
+
+# Required. Only applicable is SPARK_SKIP_BUILD is false. The git repository used to clone copies of
+# Spark to path/to/express-D/spark.
+SPARK_GIT_REPO = "git://github.com/mesos/spark.git -b branch-0.7"
+
+# Required. Location of the Express-D root directory.
+EXPRESS_D_HOME = "/home/hadoop/src/express-d"
+
+# If true, don't build Express-D. Assumes that EXPRESS_D_HOME has a target directory that contains
+# the assembly jar.
+EXPRESS_D_SKIP_PREP = False
+
+TIMINGS_OUTPUT_FILE = "express-D-run-%s" % time.strftime("%Y-%m-%d_%H-%M-%S")
+
+# --------------------------------------------------------------------------------------------------
+# General Configuration Options
+# --------------------------------------------------------------------------------------------------
+SCALA_CMD = "scala"
+
+# This default setting assumes we are running on the Spark EC2 AMI. Users will probably want
+# to change this to SPARK_CLUSTER_URL = "local" for running locally.
+# SPARK_CLUSTER_URL = open("/root/spark-ec2/cluster-url", 'r').readline().strip()
+SPARK_CLUSTER_URL = "local"
+
+# --------------------------------------------------------------------------------------------------
+# Spark + Express-D Runtime Options/Properties
+#
+# Note: these are actually Java options that will be passed to the SCALA_CMD call. Calling them
+#       Java options are a bit confusing...
+# --------------------------------------------------------------------------------------------------
+
+# Global options specific to Spark.
+SPARK_RUNTIME_OPTS = [
+    # Fraction of JVM memory used for caching RDDs.
+    JavaOptionSet("spark.storage.memoryFraction", [0.66]),
+    JavaOptionSet("spark.serializer", ["spark.JavaSerializer"]),
+    # How much memory to give the Spark process running on each slave.
+    JavaOptionSet("spark.executor.memory", ["4g"]),
+]
+
+# Global options specific to Express-D.
+EXPRESS_RUNTIME_OPTS = [
+    JavaOptionSet("express.persist.serialize", ["false"]),
+    JavaOptionSet("express.outputInterval", [5000]),
+    JavaOptionSet("express.targetParallelism", [20]),
+]
+
+ALL_JAVA_OPTS = SPARK_RUNTIME_OPTS + EXPRESS_RUNTIME_OPTS
+
+# Options local to each Express-D run.
+EXPRESS_RUNTIME_LOCAL_OPTS = [
+    OptionSet("hits-file-path", [""]),
+    OptionSet("targets-file-path", [""]),
+    OptionSet("should-use-bias", ["true"]),
+    OptionSet("num-iterations", ["1000"]),
+    OptionSet("should-cache", ["true"]),
+    # Optional.
+    OptionSet("num-partitions-for-alignments", ["-1"]),
+    OptionSet("debug-output", ["false"]),
+]
+
+# A tuple of (short_name, test_cmd, scale_factor, java_opt_sets, opt_sets)
+EXPRESS_RUN = [("Express-D", "expressd.ExpressRunner", 1.0, ALL_JAVA_OPTS, EXPRESS_RUNTIME_LOCAL_OPTS)]

--- a/config/config.py
+++ b/config/config.py
@@ -80,7 +80,7 @@ ALL_JAVA_OPTS = SPARK_RUNTIME_OPTS + EXPRESS_RUNTIME_OPTS
 
 # Options local to each Express-D run.
 EXPRESS_RUNTIME_LOCAL_OPTS = [
-    OptionSet("hits-file-path", ["/mapr/MapR_EMR.amazonaws.com/data/eXpress/x.eXpressD"]),
+    OptionSet("hits-file-path", ["/mapr/MapR_EMR.amazonaws.com/data/eXpress/hits.pb"]),
     OptionSet("targets-file-path", ["/mapr/MapR_EMR.amazonaws.com/data/eXpress/targets.pb"]),
     OptionSet("should-use-bias", ["true"]),
     OptionSet("num-iterations", ["1000"]),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,8 @@ resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositori
 
 resolvers += Resolver.url("artifactory", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
+resolvers += "Bintray sbt plugin releases" at "http://dl.bintray.com/sbt/sbt-plugin-releases/"
+
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositori
 
 resolvers += Resolver.url("artifactory", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.0-SNAPSHOT")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")

--- a/src/main/scala/expressd/ExpressD.scala
+++ b/src/main/scala/expressd/ExpressD.scala
@@ -1041,7 +1041,8 @@ object ExpressD {
             val misc2R = right._4(i)
             val misc3R = right._5(i)
 
-            val pairLength = rightStart - leftStart + 1
+            //val pairLength = rightStart - leftStart + 1
+            val pairLength = Math.abs(rightStart - leftStart) + 1
 
             // Correct for numerical issues
             val p = likelihoods.get(i) / newTotLikelihood

--- a/src/main/scala/expressd/ExpressD.scala
+++ b/src/main/scala/expressd/ExpressD.scala
@@ -19,6 +19,7 @@ import expressd.protobuf._
 import spark.SparkMemoryUtilities
 
 import org.apache.spark.{Accumulable, AccumulableParam}
+import org.apache.spark.AccumulatorParam
 import org.apache.spark.broadcast.{HttpBroadcast, Broadcast}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{SparkContext, SparkEnv}
@@ -1068,7 +1069,13 @@ object ExpressD {
 
       // ===== Debugging =====
       // Print out some memory usage info.
-      var accumFragmentsSize = sc.accumulable(0.0)
+      //var lap = new LongAccumulatorParam()
+      //var accumulatorName = "FragmentsSizeAccumulator"
+      //var accumulatorInit = 0L
+      //LongAccumulatorParam()
+      //var accumFragmentsSize = sc.accumulable(0L, "afs", lap)
+      //var accumFragmentsSize = sc.accumulator(accumulatorInit, accumulatorName, lap)
+      var accumFragmentsSize = sc.accumulable(0L)(org.apache.spark.SparkContext.LongAccumulatorParam)
 
       if (true) {
         processedRDD.mapPartitions{ partition =>

--- a/src/main/scala/expressd/ExpressD.scala
+++ b/src/main/scala/expressd/ExpressD.scala
@@ -883,12 +883,6 @@ object ExpressD {
 
 
           for (i <- 0 until numAlignments) {
-            //if ( left._1(i) > right._1(i) ) {
-            //  val t = left
-            //  left = right
-            //  right = t
-            //}
-
             val pairTargetId = fragment._1(i)
             val leftFirst = fragment._2(i)
             val leftStart = left._1(i)
@@ -902,10 +896,8 @@ object ExpressD {
             val misc2R = right._4(i)
             val misc3R = right._5(i)
 
-            //val pairLength = rightStart - leftStart + 1
             val pairLength = Math.abs(rightStart - leftStart) + 1
 
-            //println("pairLength=" + pairLength + " pairTargetId=" + pairTargetId)
             val bcTausValue = bcTaus.value(pairTargetId)
             val bcFldValue = bcFld.value(pairLength)
             val bcEffLengthsValue = bcEffLengths.value(pairTargetId)
@@ -1041,7 +1033,6 @@ object ExpressD {
             val misc2R = right._4(i)
             val misc3R = right._5(i)
 
-            //val pairLength = rightStart - leftStart + 1
             val pairLength = Math.abs(rightStart - leftStart) + 1
 
             // Correct for numerical issues

--- a/src/main/scala/expressd/ExpressD.scala
+++ b/src/main/scala/expressd/ExpressD.scala
@@ -20,7 +20,7 @@ import spark.SparkMemoryUtilities
 
 import org.apache.spark.{Accumulable, AccumulableParam}
 import org.apache.spark.AccumulatorParam
-import org.apache.spark.broadcast.{HttpBroadcast, Broadcast}
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{SparkContext, SparkEnv}
 import org.apache.spark.storage._

--- a/src/main/scala/expressd/ExpressD.scala
+++ b/src/main/scala/expressd/ExpressD.scala
@@ -881,7 +881,14 @@ object ExpressD {
           val left = fragment._3
           val right = fragment._4
 
+
           for (i <- 0 until numAlignments) {
+            //if ( left._1(i) > right._1(i) ) {
+            //  val t = left
+            //  left = right
+            //  right = t
+            //}
+
             val pairTargetId = fragment._1(i)
             val leftFirst = fragment._2(i)
             val leftStart = left._1(i)
@@ -895,9 +902,17 @@ object ExpressD {
             val misc2R = right._4(i)
             val misc3R = right._5(i)
 
-            val pairLength = rightStart - leftStart + 1
+            //val pairLength = rightStart - leftStart + 1
+            val pairLength = Math.abs(rightStart - leftStart) + 1
+
+            //println("pairLength=" + pairLength + " pairTargetId=" + pairTargetId)
+            val bcTausValue = bcTaus.value(pairTargetId)
+            val bcFldValue = bcFld.value(pairLength)
+            val bcEffLengthsValue = bcEffLengths.value(pairTargetId)
+
             likelihoods.set(i,
-              bcTaus.value(pairTargetId) + bcFld.value(pairLength) - bcEffLengths.value(pairTargetId))
+              bcTausValue + bcFldValue - bcEffLengthsValue
+            )
 
             val targSeq = bcTargSeqs.value(pairTargetId)
             val targLen = bcTargLens.value(pairTargetId)
@@ -922,8 +937,8 @@ object ExpressD {
             }
 
             if (shouldUpdateAllParams) {
-              errorIndices1.add(if (errorIndex1 == null) { errorIndices1.get(0) } else { errorIndex1 })
-              errorIndices2.add(if (errorIndex2 == null) { errorIndices2.get(0) } else { errorIndex2 })
+              errorIndices1.add(if (errorIndex1 == null) { if (errorIndices1.size > 0) { errorIndices1.get(0) } else { errorIndex1 } } else { errorIndex1 })
+              errorIndices2.add(if (errorIndex2 == null) { if (errorIndices2.size > 0) { errorIndices2.get(0) } else { errorIndex2 } } else { errorIndex2 })
             }
 
             // Sum current likelihood with values in errors likelihood table at MAX_READ_LENGTH indices.

--- a/src/main/scala/expressd/ExpressD.scala
+++ b/src/main/scala/expressd/ExpressD.scala
@@ -945,6 +945,8 @@ object ExpressD {
             var errLikelihood1 = LOG_1
             if (i > 0 && errorIndex1 == null) {
               errLikelihood1 = refErrLikelihood1
+            } else if ( errorIndex1 == null ) {
+              //TODO: what to do here?  was throwing NPE here -aday
             } else {
               for (j <- 0 until errorIndex1.size) {
                 val splitCode = decodeMarkovChainIndex(errorIndex1(j))
@@ -957,6 +959,8 @@ object ExpressD {
             var errLikelihood2 = LOG_1
             if (i > 0 && errorIndex2 == null) {
               errLikelihood2 = refErrLikelihood2
+            } else if ( errorIndex2 == null ) {
+              //TODO: what to do here?  was throwing NPE here -aday
             } else {
               for (j <- 0 until errorIndex2.size) {
                 val splitCode = decodeMarkovChainIndex(errorIndex2(j))
@@ -1049,13 +1053,17 @@ object ExpressD {
               val errorIndex2 = errorIndices2.get(i)
 
               newFld.localValue(pairLength) += p
-              for (j <- 0 until errorIndex1.size) {
-                val splitCode = decodeMarkovChainIndex(errorIndex1(j))
-                newErrors1.localValue(j)(splitCode._1)(splitCode._2) += p
+              if ( errorIndex1 != null ) { //TODO is this right? avert NPE -aday
+                for (j <- 0 until errorIndex1.size) {
+                  val splitCode = decodeMarkovChainIndex(errorIndex1(j))
+                  newErrors1.localValue(j)(splitCode._1)(splitCode._2) += p
+                }
               }
-              for (j <- 0 until errorIndex2.size) {
-                val splitCode = decodeMarkovChainIndex(errorIndex2(j))
-                newErrors2.localValue(j)(splitCode._1)(splitCode._2) += p
+              if ( errorIndex2 != null ) { //TODO is this right? avert NPE -aday
+                for (j <- 0 until errorIndex2.size) {
+                  val splitCode = decodeMarkovChainIndex(errorIndex2(j))
+                  newErrors2.localValue(j)(splitCode._1)(splitCode._2) += p
+                }
               }
 
               if (shouldUseBias) {

--- a/src/main/scala/expressd/ExpressD.scala
+++ b/src/main/scala/expressd/ExpressD.scala
@@ -18,13 +18,14 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import expressd.protobuf._
 import spark.SparkMemoryUtilities
 
-import spark.{Accumulable, AccumulableParam}
-import spark.broadcast.{HttpBroadcast, Broadcast}
-import spark.{RDD, SparkContext, SparkEnv}
-import spark.storage._
+import org.apache.spark.{Accumulable, AccumulableParam}
+import org.apache.spark.broadcast.{HttpBroadcast, Broadcast}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{SparkContext, SparkEnv}
+import org.apache.spark.storage._
 
-import spark.SparkContext
-import spark.SparkContext._
+import org.apache.spark.SparkContext
+import org.apache.spark.SparkContext._
 
 // For debugging.
 import scala.runtime.ScalaRunTime._

--- a/src/main/scala/expressd/ExpressEnv.scala
+++ b/src/main/scala/expressd/ExpressEnv.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable.HashMap
 // Import InputFormat classes
 import org.apache.hadoop.mapreduce.lib.input._
 
-import spark.SparkContext
+import org.apache.spark.SparkContext
 
 object ExpressEnv {
 

--- a/src/main/scala/expressd/ExpressEnv.scala
+++ b/src/main/scala/expressd/ExpressEnv.scala
@@ -46,7 +46,7 @@ object ExpressEnv {
 
   val BIAS_WINDOW = System.getProperty("express.biasWindow", "8").toInt
   val BIAS_MATRIX_SIZE = BIAS_WINDOW * 2 + 1
-  val MAX_FRAG_LENGTH = System.getProperty("express.maxFragLength", "800").toInt
+  val MAX_FRAG_LENGTH = System.getProperty("express.maxFragLength", "10000").toInt
   val MAX_READ_LENGTH = System.getProperty("express.maxReadLength", "200").toInt
 
   val BURN_IN_ITERATIONS = System.getProperty("express.burnInIterations", "20").toInt

--- a/src/main/scala/expressd/ExpressRunner.scala
+++ b/src/main/scala/expressd/ExpressRunner.scala
@@ -8,14 +8,14 @@ import scala.collection.mutable.ArrayBuffer
 
 import joptsimple.{OptionSet, OptionParser}
 
-import spark.{Accumulable, AccumulableParam}
-import spark.SparkContext
-import spark.SparkContext._
-import spark.SparkEnv
-import spark.RDD
+import org.apache.spark.{Accumulable, AccumulableParam}
+import org.apache.spark.SparkContext
+import org.apache.spark.SparkContext._
+import org.apache.spark.SparkEnv
+import org.apache.spark.rdd.RDD
 import spark.SparkMemoryUtilities
-import spark.broadcast.{HttpBroadcast, Broadcast}
-import spark.storage._
+import org.apache.spark.broadcast.{HttpBroadcast, Broadcast}
+import org.apache.spark.storage._
 
 
 object ExpressRunner {

--- a/src/main/scala/spark/SparkMemoryUtilities.scala
+++ b/src/main/scala/spark/SparkMemoryUtilities.scala
@@ -12,10 +12,6 @@ object SparkMemoryUtilities {
    */
   def dropBroadcastVar(bcVar: Broadcast[_]) {
     bcVar.unpersist()
-
-    //val blockManager = SparkEnv.get.blockManager
-    //val broadcastBlockId = bcVar.asInstanceOf[HttpBroadcast[_]].blockId
-    //blockManager.removeBlock(broadcastBlockId)
   }
 
   def estimateSize(obj: AnyRef): Long = {

--- a/src/main/scala/spark/SparkMemoryUtilities.scala
+++ b/src/main/scala/spark/SparkMemoryUtilities.scala
@@ -2,6 +2,7 @@ package spark
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.broadcast.{HttpBroadcast, Broadcast}
+import org.apache.spark.util.SizeEstimator
 
 object SparkMemoryUtilities {
 

--- a/src/main/scala/spark/SparkMemoryUtilities.scala
+++ b/src/main/scala/spark/SparkMemoryUtilities.scala
@@ -1,7 +1,7 @@
 package spark
 
 import org.apache.spark.SparkEnv
-import org.apache.spark.broadcast.{HttpBroadcast, Broadcast}
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.util.SizeEstimator
 
 object SparkMemoryUtilities {
@@ -11,9 +11,11 @@ object SparkMemoryUtilities {
    * local Spark process.
    */
   def dropBroadcastVar(bcVar: Broadcast[_]) {
-    val blockManager = SparkEnv.get.blockManager
-    val broadcastBlockId = bcVar.asInstanceOf[HttpBroadcast[_]].blockId
-    blockManager.removeBlock(broadcastBlockId)
+    bcVar.unpersist()
+
+    //val blockManager = SparkEnv.get.blockManager
+    //val broadcastBlockId = bcVar.asInstanceOf[HttpBroadcast[_]].blockId
+    //blockManager.removeBlock(broadcastBlockId)
   }
 
   def estimateSize(obj: AnyRef): Long = {

--- a/src/main/scala/spark/SparkMemoryUtilities.scala
+++ b/src/main/scala/spark/SparkMemoryUtilities.scala
@@ -1,6 +1,7 @@
 package spark
 
-import spark.broadcast.{HttpBroadcast, Broadcast}
+import org.apache.spark.SparkEnv
+import org.apache.spark.broadcast.{HttpBroadcast, Broadcast}
 
 object SparkMemoryUtilities {
 


### PR DESCRIPTION
This patch addresses two problems:
- brings eXpress-D up to date to run on scala 2.10 and spark 1.4.1
- edge conditions related to uninitialized arrays in src/main/scala/expressd/ExpressD.scala -- I need some feedback here to know if I've handled them correctly.
